### PR TITLE
Apply correct arguments 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,7 +63,7 @@ exports.replace = function (obj, path, fn, options) {
     invocations++;
 
     if (invocations < startOn) {
-      return func.apply(this, args);
+      return func.apply(this, arguments);
     }
 
     if (invocations === options.stopAfter) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "stub"
   ],
   "devDependencies": {
-    "belly-button": "1.x.x",
+    "belly-button": "2.x.x",
     "code": "1.x.x",
     "lab": "6.x.x"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -153,7 +153,7 @@ describe('stand-in', function () {
     });
 
     it('only activate the stand for certain invocations', function (done) {
-      var obj = { method: function () { return -1; } };
+      var obj = { method: function (value) { return -1 * value; } };
       var calls = 0;
       var stand = StandIn.replace(obj, 'method', function (stand, value) {
         calls++;
@@ -166,7 +166,7 @@ describe('stand-in', function () {
         obj.method(2),
         obj.method(3),
         obj.method(4)
-      ]).to.deep.equal([-1, 2, 3, -1]);
+      ]).to.deep.equal([-1, 2, 3, -4]);
       expect(obj.method).to.equal(stand.original);
       expect(stand.invocations).to.equal(3);
       expect(calls).to.equal(2);


### PR DESCRIPTION
Looks like the old version of `belly-button` did not catch variable use before they are defined. Fixed that and updated `belly-button` version. Also are you aware that `belly-button` errors on **asi**, I think that might be a bug?
